### PR TITLE
Default features json

### DIFF
--- a/zrpc-macros/Cargo.toml
+++ b/zrpc-macros/Cargo.toml
@@ -30,6 +30,7 @@ zenoh-util = { version = "=0.6.0-beta.1" }
 zrpc = { path = "../zrpc" }
 
 [dev-dependencies]
+serde_json = "1"
 env_logger = "=0.9.1"
 
 [lib]

--- a/zrpc-macros/Cargo.toml
+++ b/zrpc-macros/Cargo.toml
@@ -27,7 +27,7 @@ uhlc = "=0.5"
 uuid = { version = "=1.1", features = ["serde", "v4"] }
 zenoh = { version = "=0.6.0-beta.1", default-features = false }
 zenoh-util = { version = "=0.6.0-beta.1" }
-zrpc = { path = "../zrpc" }
+zrpc = { path = "../zrpc", default-features = false }
 
 [dev-dependencies]
 serde_json = "1"

--- a/zrpc-macros/examples/zservice.rs
+++ b/zrpc-macros/examples/zservice.rs
@@ -34,6 +34,7 @@ use zrpc_macros::{zserver, zservice};
 pub trait Hello {
     async fn hello(&self, name: String) -> String;
     async fn add(&mut self) -> u64;
+    async fn test_serde_json_value(&self, value: serde_json::Value) -> bool;
 }
 
 #[derive(Clone)]
@@ -52,6 +53,13 @@ impl Hello for HelloZService {
         let mut guard = self.counter.lock().await;
         *guard += 1;
         *guard
+    }
+
+    async fn test_serde_json_value(&self, value: serde_json::Value) -> bool {
+        match value {
+            serde_json::Value::Bool(b) => b,
+            _ => false,
+        }
     }
 }
 
@@ -113,6 +121,10 @@ async fn main() {
     println!("Res is: {:?}", res);
 
     let res = client.add().await;
+    println!("Res is: {:?}", res);
+
+    let req = serde_json::Value::Bool(true);
+    let res = client.test_serde_json_value(req).await;
     println!("Res is: {:?}", res);
 
     server.stop(s).await.unwrap();

--- a/zrpc/Cargo.toml
+++ b/zrpc/Cargo.toml
@@ -21,6 +21,7 @@ thiserror = "=1.0"
 uuid = { version = "=1.1", features = ["serde", "v4"] }
 zenoh = { version = "=0.6.0-beta.1", default-features = false }
 zenoh-util = { version = "=0.6.0-beta.1" }
+
 [features]
 #zenoh feature re-exports
 auth_pubkey = ["zenoh/auth_pubkey"]
@@ -50,9 +51,4 @@ state_cbor = ["serde_cbor"]
 
 router_json = ["serde_json"]
 
-default = ["resp_cbor", "send_cbor", "state_cbor", "router_json", "transport_tcp", "transport_udp"]
-
-
-
-
-
+default = ["resp_json", "send_json", "state_json", "router_json", "transport_tcp", "transport_udp"]

--- a/zrpc/src/serialize.rs
+++ b/zrpc/src/serialize.rs
@@ -138,6 +138,9 @@ where
     #[cfg(feature = "send_json")]
     return Ok(serde_json::from_str::<T>(std::str::from_utf8(raw_data)?)?);
 
+    #[cfg(feature = "send_bincode")]
+    return Ok(bincode::deserialize::<T>(&raw_data)?);
+
     #[cfg(feature = "send_cbor")]
     return Ok(serde_cbor::from_slice::<T>(raw_data)?);
 }


### PR DESCRIPTION
The main purpose of this PR is to make json the default format for serialization / deserialization.

We have deserialization errors when using CBOR and Bincode, the latter because of `serde_json::Value` that it cannot handle properly.

As these errors do not happen when using json, we make it the default.